### PR TITLE
clippy

### DIFF
--- a/benches/general.rs
+++ b/benches/general.rs
@@ -1,8 +1,12 @@
 #![feature(test)]
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
-#![warn(missing_docs)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or
+)]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
 
 extern crate test;
 

--- a/benches/general.rs
+++ b/benches/general.rs
@@ -1,4 +1,8 @@
 #![feature(test)]
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+#![warn(missing_docs)]
 
 extern crate test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,12 @@
 
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
-#![warn(missing_docs)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or
+)]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
 
 /// Encrypt single byte with secure ROT13 function
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,12 @@
 
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
-#![warn(missing_docs)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or
+)]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
 
 use anyhow::bail;
 use clap::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
+//! {{project-name}} executable.
+
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+#![warn(missing_docs)]
 
 use anyhow::bail;
 use clap::Parser;
@@ -10,6 +13,7 @@ use simplelog::{
 };
 use std::process::exit;
 
+/// Parameters to configure executable.
 #[derive(Debug, clap::Parser)]
 #[clap(version, about)]
 struct Params {
@@ -27,6 +31,7 @@ fn main() {
     });
 }
 
+/// Set up and run executable.
 #[allow(clippy::unused_async)]
 async fn cli(params: Params) -> anyhow::Result<()> {
     let filter = match params.verbose {
@@ -59,12 +64,13 @@ async fn cli(params: Params) -> anyhow::Result<()> {
     Ok(())
 }
 
-// Using `Box` isn’t our decision here.
-#[allow(clippy::unnecessary_box_returns)]
+/// Convenience function to make creating [`TermLogger`]s clearer.
+#[allow(clippy::unnecessary_box_returns)] // Using `Box` isn’t our decision.
 fn new_term_logger(level: LevelFilter, config: Config) -> Box<TermLogger> {
     TermLogger::new(level, config, TerminalMode::Mixed, ColorChoice::Auto)
 }
 
+/// Convenience function to make creating [`ConfigBuilder`]s clearer.
 fn new_logger_config() -> ConfigBuilder {
     let mut builder = ConfigBuilder::new();
     builder.set_target_level(LevelFilter::Error);


### PR DESCRIPTION
- Apply same Clippy lints to all code.
- Clippy: allow manual_string_new, warn on missing private docs.
